### PR TITLE
add a dockerfile to data-store-loader

### DIFF
--- a/data-store-loader/Dockerfile
+++ b/data-store-loader/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:latest
+
+COPY * /opt/data-loader/
+
+WORKDIR /opt/data-loader
+
+RUN yum -y install epel-release && \
+    yum -y install python-pip && \
+    yum clean all
+
+RUN pip install -r requirements.txt
+
+CMD ["python", "app.py"]

--- a/data-store-loader/README.md
+++ b/data-store-loader/README.md
@@ -35,14 +35,11 @@ for more information about the options and defaults run this:
 ## Running with Docker
 
 This application can be built as a container image and run with docker. To
-start create the image using the
-[S2I](https://github.com/openshift/source-to-image) tool, as follows:
+start create the image using the following command in the `data-store-loader`
+directory:
 
 ```
-s2i build https://github.com/radanalyticsio/jiminy-tools.git \
-    centos/python-27-centos7 \
-    --context-dir=data-store-loader \
-    data-store-loader
+docker -t data-store-loader .
 ```
 
 Next launch a postgres container, for example:


### PR DESCRIPTION
This change is to help automate the building of the data store loader
for users who will utilize the openshift job. This will also enable
auto-building of an image through docker hub.