### PR TITLE
added logging info stating that ratings and products have been loaded

### DIFF
--- a/data-store-loader/app.py
+++ b/data-store-loader/app.py
@@ -126,7 +126,9 @@ if __name__ == '__main__':
     if movies_csv is not None:
         logging.info('loading products table')
         movielens.load_products_data(conn, movies_csv)
+        logging.info('loaded products table')
 
     if ratings_csv is not None:
         logging.info('loading ratings table')
         movielens.load_ratings_data(conn, ratings_csv)
+        logging.info('loaded ratings table')


### PR DESCRIPTION
Previously, the logging stated that the data sets were "loading" but did not give notification that they had "loaded". I added these. 

n.b. I will need to update the screenshots in the jiminy tutorial to reflect this change, once the PR is merged. 